### PR TITLE
Https double scan and dns cloaking

### DIFF
--- a/analyse/dns_resolver.py
+++ b/analyse/dns_resolver.py
@@ -1,0 +1,16 @@
+import dns.resolver
+
+
+RESOLVER = dns.resolver.Resolver()
+RESOLVER.nameservers = [
+    '1.1.1.1',  # Cloudflare
+    '9.9.9.9',  # Quad9
+]
+
+
+def resolve_cname(domain):
+    try:
+        answers = RESOLVER.resolve(domain, 'CNAME')
+        return str(answers[0]) if len(answers) > 0 else None
+    except:
+        return None

--- a/analyse/requirements.txt
+++ b/analyse/requirements.txt
@@ -4,6 +4,7 @@ certifi==2021.10.8
 cffi==1.15.0
 charset-normalizer==2.0.12
 cryptography==36.0.1
+dnspython==2.2.0
 filelock==3.5.1
 h11==0.13.0
 idna==3.3


### PR DESCRIPTION
- Analysis is run twice first on http:// and then if supported on https://
- Refactor on `browser.py` to make it easier to run multiple scans
- In case sudomain is used in cookies, cname dns resolution is run to check if the tracker is cloaking it.